### PR TITLE
fix(build): do not break if the rule don't have options

### DIFF
--- a/lib/webpack.js
+++ b/lib/webpack.js
@@ -111,6 +111,7 @@ exports.getWebpackConfig = ({ target }) => {
   for (const rule of webpackConfig.module.rules) {
     if (rule.use) {
       for (const item of rule.use) {
+        item.options = item.options || {}
         if (item.loader === 'cache-loader' && !isClient) {
           // Change cache directory for server-side
           item.options.cacheIdentifier += '-server'


### PR DESCRIPTION
The build breaks if cache-loader or vue-loader doesn't define options