### PR TITLE
feat(Server): Add express middlewares inside config

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -88,10 +88,8 @@ module.exports = (app, options) => {
       }
     })
 
-    config.middlewares.forEach(({method = null, args = []}) => {
-      if (method) {
-        app.use(method(...args))
-      }
+    config.middlewares.forEach(middleware => {
+      app.use(middleware)
     })
 
     // Render the Vue app using the bundle renderer

--- a/lib/app.js
+++ b/lib/app.js
@@ -88,6 +88,12 @@ module.exports = (app, options) => {
       }
     })
 
+    config.middlewares.forEach(({method = null, args = []}) => {
+      if (method) {
+        app.use(method(...args))
+      }
+    })
+
     // Render the Vue app using the bundle renderer
     const renderApp = (req, res) => {
       res.setHeader('Content-Type', 'text/html')

--- a/lib/config.js
+++ b/lib/config.js
@@ -11,4 +11,5 @@ module.exports = {
   distPath: null,
   templatePath: null,
   serviceWorkerPath: null,
+  middlewares: [],
 }


### PR DESCRIPTION
It allow developers to add somme middleware to express (inside app.use())

For exemple, I wanted to have cookie inside my req, so I wanted to add cookie-parser

Use in vue.config.js

```javascript
const cookieParser = require('cookie-parser');

module.exports = {
  pluginOptions: {
    ssr: {
      middlewares: [cookieParser()]
    },
  },
};

```