### PR TITLE
feat(Directives): Add directive SSR fallback

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -27,6 +27,8 @@ module.exports = (app, options) => {
     // when receiving a SSR request
     let readyPromise
 
+    const directives = config.directives
+
     const defaultRendererOptions = {
       cache: LRU({
         max: 1000,
@@ -34,6 +36,7 @@ module.exports = (app, options) => {
       }),
       runInNewContext: false,
       inject: false,
+      directives,
     }
 
     if (isProd) {

--- a/lib/config.js
+++ b/lib/config.js
@@ -13,4 +13,5 @@ module.exports = {
   distPath: null,
   templatePath: null,
   serviceWorkerPath: null,
+  directives: {},
 }


### PR DESCRIPTION
The goal is to match the vue ssr doc and allow the use of directives on server side [https://ssr.vuejs.org/api/#directives](https://ssr.vuejs.org/api/#directives).
The usage will look like the nuxt one. [https://fr.nuxtjs.org/api/configuration-render/](https://fr.nuxtjs.org/api/configuration-render/)

## Usage

If you have a directive which adds red color to a div

```javascript
export default {
    inserted(el) {
        el.style.color = 'red';
    }
}
```

```javascript
Vue.directive('red', red);
```

```html
<div v-red> My red text </div>
```

This directive can't work with SSR. So we need a fallback. 

SSR directive of red : `red-server.js`
```javascript
/**
* @param node the VNode where we applied the directive
* @param dir properties of the directive
*/
module.exports = function(node, dir) {
  // get the current style of the node. If it doesn't have one, we create it
  const style = node.data.style || (node.data.style = {})
  // the style can be an array or an object
    if (Array.isArray(style)) {
     //if it's an array, we add a new style in it
      style.push({ color: 'red' })
    } else {
     // else we just set the color to red
      style.color = 'red'
    }
};
```

Finally, register the directive inside `vue.config.js`
```javascript
const red = require('red-server');

module.exports = {
  pluginOptions: {
    ssr: {
      directives: {
        red,
      },
    },
  },
};

```
