### PR TITLE
Feat: Add config option to run the built in server in cluster mode and to ignore some files of being added with resource hints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.idea/

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -12,6 +12,10 @@ module.exports = {
       port: null,
       // Listening host for `serve` command
       host: null,
+      // Specify public file paths to disable resource prefetch hints for
+      shouldNotPrefetch: [],
+      // Specify public file paths to disable resource preload hints for
+      shouldNotPreload: [],
       // Entry for each target
       entry: target => `./src/entry-${target}`,
       // Default title

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -22,6 +22,8 @@ module.exports = {
       skipRequests: req => req.originalUrl === '/graphql',
       // See https://ssr.vuejs.org/guide/build-config.html#externals-caveats
       nodeExternalsWhitelist: [/\.css$/, /\?vue&type=style/],
+      // Enable node cluster for the production server
+      clustered: false,
       // Function to connect custom middlewares
       extendServer: app => {
         const cookieParser = require('cookie-parser')

--- a/lib/app.js
+++ b/lib/app.js
@@ -53,11 +53,11 @@ module.exports = (app, options) => {
         template,
         clientManifest,
         shouldPrefetch: (file, type) => {
-          if (config.shouldNotPrefetch.includes(file)) return false
+          if (config.shouldNotPrefetch.indexOf(file) > -1) return false
           if (type === 'script' || type === 'style') return true
         },
         shouldPreload: (file, type) => {
-          if (config.shouldNotPreload.includes(file)) return false
+          if (config.shouldNotPreload.indexOf(file) > -1) return false
           if (type === 'script' || type === 'style') return true
         },
       })
@@ -74,11 +74,11 @@ module.exports = (app, options) => {
             ...defaultRendererOptions,
             ...options,
             shouldPrefetch: (file, type) => {
-              if (config.shouldNotPrefetch.includes(file)) return false
+              if (config.shouldNotPrefetch.indexOf(file) > -1) return false
               if (type === 'script' || type === 'style') return true
             },
             shouldPreload: (file, type) => {
-              if (config.shouldNotPreload.includes(file)) return false
+              if (config.shouldNotPreload.indexOf(file) > -1) return false
               if (type === 'script' || type === 'style') return true
             },
           })

--- a/lib/app.js
+++ b/lib/app.js
@@ -53,7 +53,6 @@ module.exports = (app, options) => {
         template,
         clientManifest,
         shouldPrefetch: (file, type) => {
-          console.log('yay:', file)
           if (config.shouldNotPrefetch.includes(file)) return false
           if (type === 'script' || type === 'style') return true
         },
@@ -75,7 +74,6 @@ module.exports = (app, options) => {
             ...defaultRendererOptions,
             ...options,
             shouldPrefetch: (file, type) => {
-              console.log('yay:', file)
               if (config.shouldNotPrefetch.includes(file)) return false
               if (type === 'script' || type === 'style') return true
             },

--- a/lib/app.js
+++ b/lib/app.js
@@ -40,6 +40,14 @@ module.exports = (app, options) => {
       runInNewContext: false,
       inject: false,
       directives,
+      shouldPrefetch: (file, type) => {
+        if (config.shouldNotPrefetch.indexOf(file) > -1) return false
+        if (type === 'script' || type === 'style') return true
+      },
+      shouldPreload: (file, type) => {
+        if (config.shouldNotPreload.indexOf(file) > -1) return false
+        if (type === 'script' || type === 'style') return true
+      },
     }
 
     if (isProd) {
@@ -55,14 +63,6 @@ module.exports = (app, options) => {
         ...defaultRendererOptions,
         template,
         clientManifest,
-        shouldPrefetch: (file, type) => {
-          if (config.shouldNotPrefetch.indexOf(file) > -1) return false
-          if (type === 'script' || type === 'style') return true
-        },
-        shouldPreload: (file, type) => {
-          if (config.shouldNotPreload.indexOf(file) > -1) return false
-          if (type === 'script' || type === 'style') return true
-        },
       })
     } else {
       // In development: setup the dev server with watch and hot-reload,
@@ -76,14 +76,6 @@ module.exports = (app, options) => {
           renderer = createBundleRenderer(serverBundle, {
             ...defaultRendererOptions,
             ...options,
-            shouldPrefetch: (file, type) => {
-              if (config.shouldNotPrefetch.indexOf(file) > -1) return false
-              if (type === 'script' || type === 'style') return true
-            },
-            shouldPreload: (file, type) => {
-              if (config.shouldNotPreload.indexOf(file) > -1) return false
-              if (type === 'script' || type === 'style') return true
-            },
           })
         },
       })

--- a/lib/app.js
+++ b/lib/app.js
@@ -30,7 +30,7 @@ module.exports = (app, options) => {
     const directives = config.directives
 
     const defaultRendererOptions = {
-      cache: LRU({
+      cache: new LRU({
         max: 1000,
         maxAge: 1000 * 60 * 15,
       }),

--- a/lib/app.js
+++ b/lib/app.js
@@ -52,6 +52,15 @@ module.exports = (app, options) => {
         ...defaultRendererOptions,
         template,
         clientManifest,
+        shouldPrefetch: (file, type) => {
+          console.log('yay:', file)
+          if (config.shouldNotPrefetch.includes(file)) return false
+          if (type === 'script' || type === 'style') return true
+        },
+        shouldPreload: (file, type) => {
+          if (config.shouldNotPreload.includes(file)) return false
+          if (type === 'script' || type === 'style') return true
+        },
       })
     } else {
       // In development: setup the dev server with watch and hot-reload,
@@ -65,6 +74,15 @@ module.exports = (app, options) => {
           renderer = createBundleRenderer(serverBundle, {
             ...defaultRendererOptions,
             ...options,
+            shouldPrefetch: (file, type) => {
+              console.log('yay:', file)
+              if (config.shouldNotPrefetch.includes(file)) return false
+              if (type === 'script' || type === 'style') return true
+            },
+            shouldPreload: (file, type) => {
+              if (config.shouldNotPreload.includes(file)) return false
+              if (type === 'script' || type === 'style') return true
+            },
           })
         },
       })

--- a/lib/config.js
+++ b/lib/config.js
@@ -3,6 +3,7 @@ module.exports = {
   service: null,
   port: null,
   host: null,
+  cluster: false,
   entry: target => `./src/entry-${target}`,
   defaultTitle: 'My app',
   favicon: './public/favicon.ico',

--- a/lib/config.js
+++ b/lib/config.js
@@ -3,7 +3,7 @@ module.exports = {
   service: null,
   port: null,
   host: null,
-  cluster: false,
+  clustered: false,
   entry: target => `./src/entry-${target}`,
   defaultTitle: 'My app',
   favicon: './public/favicon.ico',

--- a/lib/config.js
+++ b/lib/config.js
@@ -4,6 +4,8 @@ module.exports = {
   port: null,
   host: null,
   clustered: false,
+  shouldNotPrefetch: [],
+  shouldNotPreload: [],
   entry: target => `./src/entry-${target}`,
   defaultTitle: 'My app',
   favicon: './public/favicon.ico',

--- a/lib/server.js
+++ b/lib/server.js
@@ -20,12 +20,12 @@ exports.createServer = ({
 
       // Notify if new worker is created
       cluster.on('online', (worker) => {
-        console.log(`Worker ${worker.process.id} is online and listening on ${host}:${port}`)
+        console.log(`[${new Date().toTimeString().split(' ')[0]}] Worker ${worker.process.id} is online and listening on ${host}:${port}`)
       })
 
       // If a worker dies, create a new one to keep the performance steady
       cluster.on('exit', (worker, code, signal) => {
-        console.log(`Worker ${worker.process.id} exited with code/signal ${code || signal}, respawning...`)
+        console.log(`[${new Date().toTimeString().split(' ')[0]}] Worker ${worker.process.id} exited with code/signal ${code || signal}, respawning...`)
         cluster.fork()
       })
 
@@ -40,7 +40,7 @@ exports.createServer = ({
           reject(err)
         } else {
           if (!clustered) {
-            console.log(`Server listening on ${host}:${port}`)
+            console.log(`[${new Date().toTimeString().split(' ')[0]}] Server listening on ${host}:${port}`)
           }
           resolve({ app, port })
         }

--- a/lib/server.js
+++ b/lib/server.js
@@ -8,14 +8,28 @@ exports.createServer = ({
   host,
 }) => {
   return new Promise(async (resolve, reject) => {
-    const isProd = process.env.NODE_ENV === 'production'
-    console.log('server started!!!!')
+    const clustered = process.env.NODE_ENV === 'production' && config.cluster
 
-    if (cluster.isMaster && isProd && config.cluster) {
+    // If the clustering mode is enabled and we are in the master process, create one worker per CPU core
+    if (cluster.isMaster && clustered) {
       let cpus = require('os').cpus().length
+      console.log(`[${new Date().toTimeString().split(' ')[0]}] Setting up clusters for ${cpus} cores`)
       for (let i = 0; i < cpus; i += 1) {
         cluster.fork()
       }
+
+      // Notify if new worker is created
+      cluster.on('online', (worker) => {
+        console.log(`Worker ${worker.process.id} is online and listening on ${host}:${port}`)
+      })
+
+      // If a worker dies, create a new one to keep the performance steady
+      cluster.on('exit', (worker, code, signal) => {
+        console.log(`Worker ${worker.process.id} exited with code/signal ${code || signal}, respawning...`)
+        cluster.fork()
+      })
+
+      // If the clustering mode is disabled or we are in a worker process, setup the server
     } else {
       const app = express()
 
@@ -25,7 +39,9 @@ exports.createServer = ({
         if (err) {
           reject(err)
         } else {
-          console.log(`Server listening on ${host}:${port}`)
+          if (!clustered) {
+            console.log(`Server listening on ${host}:${port}`)
+          }
           resolve({ app, port })
         }
       })

--- a/lib/server.js
+++ b/lib/server.js
@@ -8,7 +8,7 @@ exports.createServer = ({
   host,
 }) => {
   return new Promise(async (resolve, reject) => {
-    const clustered = process.env.NODE_ENV === 'production' && config.cluster
+    const clustered = process.env.NODE_ENV === 'production' && config.clustered
 
     // If the clustering mode is enabled and we are in the master process, create one worker per CPU core
     if (cluster.isMaster && clustered) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -20,12 +20,12 @@ exports.createServer = ({
 
       // Notify if new worker is created
       cluster.on('online', (worker) => {
-        console.log(`[${new Date().toTimeString().split(' ')[0]}] Worker ${worker.process.id} is online and listening on ${host}:${port}`)
+        console.log(`[${new Date().toTimeString().split(' ')[0]}] Worker ${worker.id} is online and listening on ${host}:${port}`)
       })
 
       // If a worker dies, create a new one to keep the performance steady
       cluster.on('exit', (worker, code, signal) => {
-        console.log(`[${new Date().toTimeString().split(' ')[0]}] Worker ${worker.process.id} exited with code/signal ${code || signal}, respawning...`)
+        console.log(`[${new Date().toTimeString().split(' ')[0]}] Worker ${worker.id} exited with code/signal ${code || signal}, respawning...`)
         cluster.fork()
       })
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,22 +1,34 @@
+const cluster = require('cluster')
 const express = require('express')
 const applyApp = require('./app')
+const config = require('./config')
 
 exports.createServer = ({
   port,
   host,
 }) => {
   return new Promise(async (resolve, reject) => {
-    const app = express()
+    const isProd = process.env.NODE_ENV === 'production'
+    console.log('server started!!!!')
 
-    await applyApp(app)
-
-    app.listen(port, host, err => {
-      if (err) {
-        reject(err)
-      } else {
-        console.log(`Server listening on ${host}:${port}`)
-        resolve({ app, port })
+    if (cluster.isMaster && isProd && config.cluster) {
+      let cpus = require('os').cpus().length
+      for (let i = 0; i < cpus; i += 1) {
+        cluster.fork()
       }
-    })
+    } else {
+      const app = express()
+
+      await applyApp(app)
+
+      app.listen(port, host, err => {
+        if (err) {
+          reject(err)
+        } else {
+          console.log(`Server listening on ${host}:${port}`)
+          resolve({ app, port })
+        }
+      })
+    }
   })
 }


### PR DESCRIPTION
First, thank you for this awesome vue-cli plugin! 

As I wanted to run the built-in server in cluster mode I've added the config option to be able to accomplish this. 
As the dev server does not need clustered mode (and also does not like it 🙈) I've adapted the `server.js ` file to set up the cluster as soon as the config option `clustered` is set to `true` and the `NODE_ENV` equals `production`. The cluster will create one worker per CPU core and also listens to the workers `exit` events to be able to fork a new one if one crashes. This prevents the server to lose all of its workers in case of failure. The workers will start the server as it was before.
If one of both rules does not apply, the server will launch as it was before my changes. 

EDIT 1: 
I've also adapted the check `isProd` in `lib/webpack.js`. Before my change, the check was based on the `VUE_CLI_MODE`. But as many developers have multiple custom Vue modes (in my case production, staging, and development) that all build and serve the app in the same way but with different Vue specific environment variables, I've changed the check to use the `NODE_ENV`. This allows the developers to have custom Vue modes and to control the build/serve process with the `NODE_ENV`.

EDIT 2:
As I needed the possibility to exclude some static assets of being added to the manifests and being prefetched/preloaded I've added 2 options to specify files from being ignored accordingly to https://ssr.vuejs.org/guide/build-config.html#client-config 