### PR TITLE
correctly set ssr:serve mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,5 +97,5 @@ module.exports = (api, options) => {
 
 module.exports.defaultModes = {
   'ssr:build': 'production',
-  'ssr:server': 'development',
+  'ssr:serve': 'development',
 }


### PR DESCRIPTION
The module currently exports a default mode for the command 'ssr:server', but the actual command is 'ssr:serve'.