### PR TITLE
fix(apollo): add fetch polyfill for client

### DIFF
--- a/generator/templates/default/src/entry-client.js
+++ b/generator/templates/default/src/entry-client.js
@@ -1,3 +1,6 @@
+<%_ if (apollo) { _%>
+import 'isomorphic-fetch'
+<%_ } _%>
 import { loadAsyncComponents } from '@akryum/vue-cli-plugin-ssr/client'
 <%_ if (pwa) { _%>
 import './registerServiceWorker'


### PR DESCRIPTION
in order to polyfill `window.fetch` we have to add it to the `entry-client.js` as well