### PR TITLE
fix(webpack): server does not need inline critical css in prod env

### DIFF
--- a/lib/webpack.js
+++ b/lib/webpack.js
@@ -33,7 +33,7 @@ exports.chainWebpack = (webpackConfig) => {
           const rule = webpackConfig.module.rule(lang).oneOf(type)
           rule.uses.delete('extract-css-loader')
           // Critical CSS
-          rule.use('css-context').loader(CssContextLoader).before('css-loader')
+          if (!isProd) rule.use('css-context').loader(CssContextLoader).before('css-loader')
         }
       }
       webpackConfig.plugins.delete('extract-css')


### PR DESCRIPTION
in prod env, server inline critical css, and client extra css。`context.renderStyles()` will  return styles
which include server's  inline critical css and the css extracted by the client.
Here's an example
![image](https://user-images.githubusercontent.com/17498633/59566565-712f5e00-9094-11e9-80b2-4cfa80812936.png)
![image](https://user-images.githubusercontent.com/17498633/59566538-3f1dfc00-9094-11e9-8827-56825ae0b1fd.png)

