### PR TITLE
Use NODE_ENV to determine if webpack should use production build instead of mode

### DIFF
--- a/lib/webpack.js
+++ b/lib/webpack.js
@@ -11,7 +11,7 @@ exports.chainWebpack = (webpackConfig) => {
   const target = process.env.VUE_CLI_SSR_TARGET
   if (!target) return
   const isClient = target === 'client'
-  const isProd = process.env.VUE_CLI_MODE === 'production'
+  const isProd = process.env.NODE_ENV === 'production'
 
   // Remove unneeded plugins
   webpackConfig.plugins.delete('hmr')


### PR DESCRIPTION
This fixes an issue relating to this bug #13.

If you are trying to build your app for "production" with modes that are not named "production", this web server fails to start because our build was not properly configured for production.

This fixes this issue by using `NODE_ENV` to determine if you are building for production so we can have multiple modes for staging/production/development that all do a production build (https://cli.vuejs.org/guide/mode-and-env.html#example-staging-mode)