### PR TITLE
Fix compatibility with vue-meta (htmlAttrs, bodyAttrs, ...)

### DIFF
--- a/lib/webpack.js
+++ b/lib/webpack.js
@@ -45,6 +45,7 @@ exports.chainWebpack = (webpackConfig) => {
   if (isProd) {
     webpackConfig.plugin('html').tap(args => {
       args[0].minify.removeComments = false
+      args[0].minify.caseSensitive = true
       return args
     })
   }


### PR DESCRIPTION
### Problem

The plugin currently minifies the html template and converts all characters to lowercase.

This breaks compatibility with some of the meta injections vue-meta offers, e.g.:
`{{{ meta.inject().htmlAttrs.text() }}}` and `{{{ meta.inject().bodyAttrs.text() }}}`.

When using those in the index.html template, the build step minifies and lowercases it, resulting in
`{{{ meta.inject().htmlattrs.text() }}}` and `{{{ meta.inject().bodyattrs.text() }}}`.

As a result the server-side rendering process throws an error (500) because it cannot resolve htmlattrs/bodyattrs.

### Solution

Enable case sensitivity for the minification step on the html webpack plugin.

Fixes #123 