### PR TITLE
docs: Clarify that webpack config goes in vue.config.js

### DIFF
--- a/docs/guide/webpack.md
+++ b/docs/guide/webpack.md
@@ -1,33 +1,44 @@
 # Webpack configuration
 
-In `api.chainWebpack` and `api.configureWebpack`, you have access to some environment variables:
+In the `chainWebpack()` and `configureWebpack()` options `vue.config.js`, you have access to some environment 
+variables:
 
 - **`process.env.VUE_CLI_SSR_TARGET`**: Either `'client'` or `'server'`
 
 - **`process.env.VUE_CLI_MODE`**: Vue CLI mode
 
-Examples:
+`vue.config.js`'s `chainWebpack()` option:
 
 ```js
-api.chainWebpack(config => {
-  if (process.env.VUE_CLI_SSR_TARGET === 'client') {
-    // Client-only config
-  } else {
-    // SSR-only config
-  }
-})
-```
-
-```js
-api.configureWebpack(config => {
-  if (process.env.VUE_CLI_SSR_TARGET === 'client') {
-    return {
+module.exports = {
+  // ...
+  chainWebpack(config => {
+    if (process.env.VUE_CLI_SSR_TARGET === 'client') {
       // Client-only config
-    }
-  } else {
-    return {
+    } else {
       // SSR-only config
     }
-  }
-})
+  }),
+  // ...
+}
+```
+
+`vue.config.js`'s `configureWebpack()` option:
+
+```js
+module.exports = {
+  // ...
+  configureWebpack(config => {
+    if (process.env.VUE_CLI_SSR_TARGET === 'client') {
+      return {
+        // Client-only config
+      }
+    } else {
+      return {
+        // SSR-only config
+      }
+    }
+  }),
+  // ...
+}
 ```


### PR DESCRIPTION
I was pretty confused by the webpack docs page, but I think I was able to figure out what it meant. The following docs changes would have saved me a good amount of time.