### PR TITLE
fix: fix compatibility with `router/` directory

### DIFF
--- a/generator/index.js
+++ b/generator/index.js
@@ -1,4 +1,5 @@
 const fs = require('fs-extra')
+const path = require('path')
 const {
   hasYarn,
 } = require('@vue/cli-shared-utils')
@@ -165,9 +166,9 @@ function getFile (api, file) {
   if (fs.existsSync(filePath)) return filePath
   filePath = api.resolve(file.replace('.js', '.ts'))
   if (fs.existsSync(filePath)) return filePath
-  filePath = api.resolve(file.replace('.js', ''), 'index.js')
+  filePath = api.resolve(path.join(file.replace('.js', ''), 'index.js'))
   if (fs.existsSync(filePath)) return filePath
-  filePath = api.resolve(file.replace('.js', ''), 'index.ts')
+  filePath = api.resolve(path.join(file.replace('.js', ''), 'index.ts'))
   if (fs.existsSync(filePath)) return filePath
 
   api.exitLog(`File ${file} not found in the project. Automatic generation will be incomplete.`, 'warn')


### PR DESCRIPTION
The `resolve` method in `GeneratorAPI` only accepts one argument, we
need to join the paths manually.

@vue/cli-plugin-router v4 is directory-based by default so this is a
critical compatibility fix.

Fixes #32.