### PR TITLE
fix: clear cache when re-creating bundle renderer

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -73,11 +73,19 @@ module.exports = (app, options) => {
         server: app,
         templatePath,
         onUpdate: ({ serverBundle }, options) => {
-          // Re-create the bundle renderer
-          renderer = createBundleRenderer(serverBundle, {
+          const mergedOptions = {
             ...defaultRendererOptions,
             ...options,
-          })
+          }
+
+          // Re-using the cache could lead to out-of-date results,
+          // so clear the cache on bundle renderer rebuild
+          if (mergedOptions.cache && mergedOptions.cache.reset) {
+            mergedOptions.cache.reset()
+          }
+
+          // Re-create the bundle renderer
+          renderer = createBundleRenderer(serverBundle, mergedOptions)
         },
       })
     }


### PR DESCRIPTION
@Akryum, this fixes an issue where cached components wouldn't be updated in the dev server when re-building the server bundle.