### PR TITLE
Add publicAppPath config option to make the app prefix independent from asset prefix

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -8,8 +8,8 @@ const path = require('path')
 module.exports = {
   pluginOptions: {
     ssr: {
-      // Allows to specify a route prefix for the app, independent from publicPath
-      publicAppPath: '/
+      // Specify a route prefix for the app independent from publicPath
+      publicAppPath: null,
       // Listening port for `serve` command
       port: null,
       // Listening host for `serve` command

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -8,6 +8,8 @@ const path = require('path')
 module.exports = {
   pluginOptions: {
     ssr: {
+      // Allows to specify a route prefix for the app, independent from publicPath
+      publicAppPath: '/
       // Listening port for `serve` command
       port: null,
       // Listening host for `serve` command

--- a/lib/app.js
+++ b/lib/app.js
@@ -173,7 +173,7 @@ module.exports = (app, options) => {
         readyPromise.then(() => renderApp(req, res)).catch(console.error)
       }
     }
-    app.get(`${publicAppPath || publicPath}*`, (req, res, next) => {
+    app.get((publicAppPath || publicPath) + '*', (req, res, next) => {
       if (config.skipRequests(req)) {
         return next()
       }

--- a/lib/app.js
+++ b/lib/app.js
@@ -100,6 +100,8 @@ module.exports = (app, options) => {
       app.use(publicPath, (req, res, next) => {
         if (/index\.html/g.test(req.path)) {
           next()
+        } else if (req.path.indexOf(publicPath) === -1) {
+          next()
         } else {
           serveStaticFiles(req, res, next)
         }

--- a/lib/app.js
+++ b/lib/app.js
@@ -173,7 +173,7 @@ module.exports = (app, options) => {
         readyPromise.then(() => renderApp(req, res)).catch(console.error)
       }
     }
-    app.get((publicAppPath || publicPath) + '*', (req, res, next) => {
+    app.get(`${publicAppPath || publicPath}*`, (req, res, next) => {
       if (config.skipRequests(req)) {
         return next()
       }

--- a/lib/app.js
+++ b/lib/app.js
@@ -100,8 +100,6 @@ module.exports = (app, options) => {
       app.use(publicPath, (req, res, next) => {
         if (/index\.html/g.test(req.path)) {
           next()
-        } else if (req.path.indexOf(publicPath) === -1) {
-          next()
         } else {
           serveStaticFiles(req, res, next)
         }

--- a/lib/app.js
+++ b/lib/app.js
@@ -19,7 +19,7 @@ module.exports = (app, options) => {
   if (options.prodOnly && !isProd) return
 
   const templatePath = config.templatePath
-  const { publicPath } = config.service.projectOptions
+  const { publicPath, publicAppPath } = config.service.projectOptions
 
   try {
     // Vue bundle renderer
@@ -172,7 +172,7 @@ module.exports = (app, options) => {
         readyPromise.then(() => renderApp(req, res)).catch(console.error)
       }
     }
-    app.get(`${config.publicAppPath || publicPath}*`, (req, res, next) => {
+    app.get(`${publicAppPath || publicPath}*`, (req, res, next) => {
       if (config.skipRequests(req)) {
         return next()
       }

--- a/lib/app.js
+++ b/lib/app.js
@@ -172,7 +172,7 @@ module.exports = (app, options) => {
         readyPromise.then(() => renderApp(req, res)).catch(console.error)
       }
     }
-    app.get(`${publicPath}*`, (req, res, next) => {
+    app.get(`${config.publicAppPath || publicPath}*`, (req, res, next) => {
       if (config.skipRequests(req)) {
         return next()
       }

--- a/lib/app.js
+++ b/lib/app.js
@@ -19,7 +19,8 @@ module.exports = (app, options) => {
   if (options.prodOnly && !isProd) return
 
   const templatePath = config.templatePath
-  const { publicPath, publicAppPath } = config.service.projectOptions
+  const { publicPath } = config.service.projectOptions
+  const { publicAppPath } = (config.service.projectOptions.pluginOptions || {}).ssr || {}
 
   try {
     // Vue bundle renderer


### PR DESCRIPTION
Hi,

in our app we have a `/de/suche/...` and a `/en/search/...` route prefix. The app lives behind a loadbalancer and those 2 prefixes are passed to the app by it. Assets thus live under `/de/suche/.../app.js` and `/en/search/.../app.js` respectively as well. Therefore we need to set `publicPath` to e.g. `/en/search`, but then `/de/suche/...` is no longer working, as vue-cli-plugin-ssr mounts the app under `publicPath`. Instead we want the app to be mounted under `'/'`, but the assets to be available at `publicPath`, as usual.

This PR adds a `publicAppPath` config option which allows to set the app path independently from the `publicPath` for assets.