### PR TITLE
Fix for dev server crash when unable to copy URL

### DIFF
--- a/lib/dev-server.js
+++ b/lib/dev-server.js
@@ -132,8 +132,13 @@ module.exports.setupDevServer = ({ server, templatePath, onUpdate }) => new Prom
     if (firstRun) {
       firstRun = false
       if (config.copyUrlOnStart) {
-        require('clipboardy').write(url)
-        copied = chalk.dim('(copied to clipboard)')
+        try {
+          require('clipboardy').write(url)
+          copied = chalk.dim('(copied to clipboard)')
+        } catch (e) {
+          // If we can't copy the link to the clipboard, just ignore the error (but still alert the user)
+          copied = chalk.dim('(failed to copy to clipboard)')
+        }
       }
     }
 


### PR DESCRIPTION
This exception is seen currently when run inside of Docker:
`ERROR  Error: Both xsel and fallback failed`

This crashes the server and is quite a pest to deal with! This PR fixes this and gracefully handles the error.