### PR TITLE
Always remove extract-css-loader on server

### DIFF
--- a/lib/webpack.js
+++ b/lib/webpack.js
@@ -24,7 +24,7 @@ exports.chainWebpack = (webpackConfig) => {
     webpackConfig.plugins.delete('friendly-errors')
 
     const isExtracting = webpackConfig.plugins.has('extract-css')
-    if (isExtracting && config.criticalCSS) {
+    if (isExtracting) {
       // Remove extract
       const langs = ['css', 'postcss', 'scss', 'sass', 'less', 'stylus']
       const types = ['vue-modules', 'vue', 'normal-modules', 'normal']
@@ -32,8 +32,9 @@ exports.chainWebpack = (webpackConfig) => {
         for (const type of types) {
           const rule = webpackConfig.module.rule(lang).oneOf(type)
           rule.uses.delete('extract-css-loader')
-          // Critical CSS
-          rule.use('css-context').loader(CssContextLoader).before('css-loader')
+          if (config.criticalCSS) {
+            rule.use('css-context').loader(CssContextLoader).before('css-loader')
+          }
         }
       }
       webpackConfig.plugins.delete('extract-css')

--- a/lib/webpack.js
+++ b/lib/webpack.js
@@ -57,6 +57,7 @@ exports.chainWebpack = (webpackConfig) => {
       ...htmlPlugin.get('args')[0],
       template: config.api.resolve('public/index.ssr.html'),
       filename: 'index.ssr.html',
+      chunks: [],
     },
   ])
 


### PR DESCRIPTION
... even when `cricitcalCSS` is disabled. This fixes the `document is not defined` bug in production mode
Fixes #186