### PR TITLE
Cache entire rendered response

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -13,6 +13,7 @@ module.exports = {
       // Listening host for `serve` command
       host: null,
       // Specify public file paths to disable resource prefetch hints for
+      // set to true to disable all prefetches.
       shouldNotPrefetch: [],
       // Specify public file paths to disable resource preload hints for
       shouldNotPreload: [],

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -39,6 +39,28 @@ module.exports = {
       lruCacheOptions: {
         // See https://ssr.vuejs.org/guide/caching.html
       },
+      // enable the entire rendered html & vuex state to be cached
+      // DO NOT CACHE IF THE USER IS LOGGED IN
+      cachedRenderResponse(context) {
+        if (context.req.headers.cookie.contains('access_token')) {
+          return false
+        }
+        if (context.url === '/') {
+          // only cache the home page
+          return true
+        }
+        // don't cache anything else
+        return false
+      },
+      // set a custom ttl per route
+      cachedRenderResponseTtl(context) {
+        if (context.url === '/') {
+          // cache for 30 minutes
+          return 1000 * 60 * 30
+        }
+        // cache for 15 minutes
+        return 1000 * 60 * 15
+      },
       // apply default middleware like compression, serving static files
       applyDefaultServer: true,
       // Function to extend app context object

--- a/lib/app.js
+++ b/lib/app.js
@@ -125,6 +125,17 @@ module.exports = (app, options) => {
         httpCode: 200,
       }, config.extendContext && config.extendContext(req, res, process))
 
+      fullRenderCache.dispose((url) => {
+        context.url = url
+        renderer.renderToString(context, (err, renderedHtml) => {
+          if (err || context.httpCode === 500) {
+            return
+          } else {
+            fullRenderCache.set(url, renderedHtml)
+          }
+        })
+      })
+
       const cachedRender = fullRenderCache.get(req.url)
 
       if (cachedRender) {

--- a/lib/app.js
+++ b/lib/app.js
@@ -11,14 +11,6 @@ const DEFAULT_OPTIONS = {
   prodOnly: false,
 }
 
-let fullRenderCache;
-if (config.cachedRenderResponse) {
-  fullRenderCache = new LRU({
-    max: 1000,
-    maxAge: 1000 * 60 * 15,
-  })
-}
-
 module.exports = (app, options) => {
   options = Object.assign({}, DEFAULT_OPTIONS, options)
 
@@ -39,6 +31,15 @@ module.exports = (app, options) => {
     const directives = config.directives
 
     const lruCacheOptions = config.lruCacheOptions || {}
+
+    let fullRenderCache;
+    if (config.cachedRenderResponse) {
+      fullRenderCache = new LRU({
+        max: 1000,
+        maxAge: 1000 * 60 * 15,
+        ...lruCacheOptions,
+      })
+    }
 
     const defaultRendererOptions = {
       cache: new LRU({
@@ -128,7 +129,7 @@ module.exports = (app, options) => {
         httpCode: 200,
       }, config.extendContext && config.extendContext(req, res, process))
 
-      if (config.cachedRenderResponse && config.cachedRenderResponse(context)) {
+      if (config.cachedRenderResponse && config.cachedRenderResponse(context) && fullRenderCache.has(req.url)) {
         const cachedRender = fullRenderCache.get(req.url)
 
         if (cachedRender) {
@@ -179,9 +180,12 @@ module.exports = (app, options) => {
           config.onRender(res, context)
         }
 
-        if (config.cachedRenderResponse && config.cachedRenderResponse(context)) {
+        if (config.cachedRenderResponse && config.cachedRenderResponse(context) && config.cachedRenderResponseTtl) {
+          fullRenderCache.set(req.url, html, config.cachedRenderResponseTtl(context))
+        } else if (config.cachedRenderResponse && config.cachedRenderResponse(context)) {
           fullRenderCache.set(req.url, html)
         }
+
         res.send(html)
       })
     }

--- a/lib/app.js
+++ b/lib/app.js
@@ -11,10 +11,13 @@ const DEFAULT_OPTIONS = {
   prodOnly: false,
 }
 
-const fullRenderCache = new LRU({
-  max: 1000,
-  maxAge: 1000 * 60 * 15,
-})
+let fullRenderCache;
+if (config.cachedRenderResponse) {
+  fullRenderCache = new LRU({
+    max: 1000,
+    maxAge: 1000 * 60 * 15,
+  })
+}
 
 module.exports = (app, options) => {
   options = Object.assign({}, DEFAULT_OPTIONS, options)
@@ -125,27 +128,18 @@ module.exports = (app, options) => {
         httpCode: 200,
       }, config.extendContext && config.extendContext(req, res, process))
 
-      fullRenderCache.dispose((url) => {
-        context.url = url
-        renderer.renderToString(context, (err, renderedHtml) => {
-          if (err || context.httpCode === 500) {
-            return
-          } else {
-            fullRenderCache.set(url, renderedHtml)
+      if (config.cachedRenderResponse && config.cachedRenderResponse(context)) {
+        const cachedRender = fullRenderCache.get(req.url)
+
+        if (cachedRender) {
+          res.status(context.httpCode)
+  
+          if (config.onRender) {
+            config.onRender(res, context)
           }
-        })
-      })
-
-      const cachedRender = fullRenderCache.get(req.url)
-
-      if (cachedRender) {
-        res.status(context.httpCode)
-
-        if (config.onRender) {
-          config.onRender(res, context)
+  
+          return res.send(cachedRender)
         }
-
-        return res.send(cachedRender)
       }
 
       renderer.renderToString(context, (err, renderedHtml) => {
@@ -185,7 +179,9 @@ module.exports = (app, options) => {
           config.onRender(res, context)
         }
 
-        fullRenderCache.set(req.url, html)
+        if (config.cachedRenderResponse && config.cachedRenderResponse(context)) {
+          fullRenderCache.set(req.url, html)
+        }
         res.send(html)
       })
     }

--- a/lib/app.js
+++ b/lib/app.js
@@ -11,6 +11,11 @@ const DEFAULT_OPTIONS = {
   prodOnly: false,
 }
 
+const fullRenderCache = new LRU({
+  max: 1000,
+  maxAge: 1000 * 60 * 15,
+})
+
 module.exports = (app, options) => {
   options = Object.assign({}, DEFAULT_OPTIONS, options)
 
@@ -42,7 +47,7 @@ module.exports = (app, options) => {
       inject: false,
       directives,
       shouldPrefetch: (file, type) => {
-        if (config.shouldNotPrefetch.indexOf(file) > -1) return false
+        if (config.shouldNotPrefetch === true || config.shouldNotPrefetch.indexOf(file) > -1) return false
         if (type === 'script' || type === 'style') return true
       },
       shouldPreload: (file, type) => {
@@ -120,6 +125,18 @@ module.exports = (app, options) => {
         httpCode: 200,
       }, config.extendContext && config.extendContext(req, res, process))
 
+      const cachedRender = fullRenderCache.get(req.url)
+
+      if (cachedRender) {
+        res.status(context.httpCode)
+
+        if (config.onRender) {
+          config.onRender(res, context)
+        }
+
+        return res.send(cachedRender)
+      }
+
       renderer.renderToString(context, (err, renderedHtml) => {
         let html = renderedHtml
 
@@ -157,6 +174,7 @@ module.exports = (app, options) => {
           config.onRender(res, context)
         }
 
+        fullRenderCache.set(req.url, html)
         res.send(html)
       })
     }


### PR DESCRIPTION
Enable the ability to cache the entire rendered response, enable custom TTL per URL and enable per request ability to enable or disable cache.