### PR TITLE
Allow devServer options from webpack config

### DIFF
--- a/lib/dev-server.js
+++ b/lib/dev-server.js
@@ -51,6 +51,7 @@ module.exports.setupDevServer = ({ server, templatePath, onUpdate }) => new Prom
   // dev middleware
   const clientCompiler = webpack(clientConfig)
   const devMiddleware = require('webpack-dev-middleware')(clientCompiler, {
+    ...clientConfig.devServer,
     publicPath: clientConfig.output.publicPath,
     noInfo: true,
     stats: 'none',


### PR DESCRIPTION
Trying to get some CORS headers to come through to the ssr dev server for static assets (woff etc). Should it just pass through any settings form the webpack config and override with your defaults?

Then its just a normal vue.config.js

```
  configureWebpack: {
    devServer: {
      headers: {
        'Access-Control-Allow-Origin': '*'
      }
    }
  },
```