### PR TITLE
Allow late redirects in onRender

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -157,7 +157,9 @@ module.exports = (app, options) => {
           config.onRender(res, context)
         }
 
-        res.send(html)
+        if (res.statusCode === context.httpCode) {
+          res.send(html)
+        }
       })
     }
 

--- a/lib/app.js
+++ b/lib/app.js
@@ -147,7 +147,7 @@ module.exports = (app, options) => {
           }
 
           html = errorHtml
-
+          context.httpCode = 500
           res.status(500)
         } else {
           res.status(context.httpCode)


### PR DESCRIPTION
Addressing issue in #144 

If there is some late app-based condition met that would require an early 301 redirect, theres no way to do this without generating an error.

This just checks the status code is as expected in the res object before progressing with the send.

Can then override using (for example):
```
onRender = (res, context) => {
  if (context.myRedirectUrl) {
    res.redirect(302, context.myRedirectUrl)
  }
}
```