### PR TITLE
Fix HTTP server errors when trying to do a HTTP redirect from components

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -123,6 +123,11 @@ module.exports = (app, options) => {
       renderer.renderToString(context, (err, renderedHtml) => {
         let html = renderedHtml
 
+        if (context.httpCode !== res.statusCode) {
+          // If someone asked for a redirection through `this.$ssrContext.req.res.redirect(302, redirectUri)` for example, take it in account
+          context.httpCode = res.statusCode
+        }
+
         if (err || context.httpCode === 500) {
           console.error(`error during render url : ${req.url}`)
 
@@ -157,7 +162,10 @@ module.exports = (app, options) => {
           config.onRender(res, context)
         }
 
-        res.send(html)
+        // In case it's a redirection the body should be sent
+        if (res.statusCode !== 301 && res.statusCode !== 302) {
+          res.send(html)
+        }
       })
     }
 


### PR DESCRIPTION
Hi,

It's to fix this issue when doing HTTP redirections:
```
Error [ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client
    at ServerResponse.setHeader (_http_outgoing.js:482:11)
    at ServerResponse.header (/Users/XXXXXXXXXX/Documents/YYYYYYY/node_modules/express/lib/response.js:767:10)
    at ServerResponse.send (/Users/XXXXXXXXXX/Documents/YYYYYYY/node_modules/express/lib/response.js:170:12)
    at renderer.renderToString (/Users/XXXXXXXXXX/Documents/YYYYYYY/node_modules/@akryum/vue-cli-plugin-ssr/lib/app.js:119:15)
    at /Users/XXXXXXXXXX/Documents/YYYYYYY/node_modules/vue-server-renderer/build.dev.js:9536:15
```

It was not critical in the past (had this 2 years ago https://github.com/Akryum/vue-cli-plugin-ssr/issues/144#issuecomment-601103458), it was just logging things into the console. But since I upgraded some Vue dependencies the "simple log" is now something making the server crashes.

_Note: my previous version of `vue-server-renderer` was `v2.6.11` and I tried upgrading to `v2.6.14`. Don't know which change exactly breaks things... but it's fine with this PR 😄_

So to avoid being stuck in a previous version I did a little trick to always respect values that could be passed to the `res` object.

Hope this helps even if the repo is no longer maintained.

In the meantime if you want to you it you can use a specific branch with some patches I made:
```
yarn add "@akryum/vue-cli-plugin-ssr@https://github.com/sneko/vue-cli-plugin-ssr#fix/http-redirections"
```

👍 